### PR TITLE
Use positional arguments in format to support py26

### DIFF
--- a/basictracer/propagation.py
+++ b/basictracer/propagation.py
@@ -58,8 +58,8 @@ class TextPropagator(object):
         self.tracer = tracer
 
     def inject(self, span_context, carrier):
-        carrier[field_name_trace_id] = '{:x}'.format(span_context.trace_id)
-        carrier[field_name_span_id] = '{:x}'.format(span_context.span_id)
+        carrier[field_name_trace_id] = '{0:x}'.format(span_context.trace_id)
+        carrier[field_name_span_id] = '{0:x}'.format(span_context.span_id)
         carrier[field_name_sampled] = str(span_context.sampled).lower()
         if span_context.baggage is not None:
             for k in span_context.baggage:


### PR DESCRIPTION
As it turns out, python 2.6's version of format is not compatible with python 2.7+ since there was an API change. python 2.6 expects a positional argument in the format string, whereas it can be omitted in 2.7

cc @bensigelman 
