### PR TITLE
Make an opt-out path for the BINARY format

### DIFF
--- a/basictracer/binary_propagator.py
+++ b/basictracer/binary_propagator.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import struct
+from .context import SpanContext
+from .propagator import Propagator
+# This can cause problems when old versions of protobuf are installed
+from .wire_pb2 import TracerState
+from opentracing import InvalidCarrierException
+
+_proto_size_bytes = 4  # bytes
+
+
+class BinaryPropagator(Propagator):
+    """A BasicTracer Propagator for Format.BINARY."""
+
+    def inject(self, span_context, carrier):
+        if type(carrier) is not bytearray:
+            raise InvalidCarrierException()
+        state = TracerState()
+        state.trace_id = span_context.trace_id
+        state.span_id = span_context.span_id
+        state.sampled = span_context.sampled
+        if span_context.baggage is not None:
+            for key in span_context.baggage:
+                state.baggage_items[key] = span_context.baggage[key]
+
+        # The binary format is {uint32}{protobuf} using big-endian for the uint
+        carrier.extend(struct.pack('>I', state.ByteSize()))
+        carrier.extend(state.SerializeToString())
+
+    def extract(self, carrier):
+        if type(carrier) is not bytearray:
+            raise InvalidCarrierException()
+        state = TracerState()
+        state.ParseFromString(str(carrier[_proto_size_bytes:]))
+        baggage = {}
+        for k in state.baggage_items:
+            baggage[k] = state.baggage_items[k]
+
+        return SpanContext(
+            span_id=state.span_id,
+            trace_id=state.trace_id,
+            baggage=baggage,
+            sampled=state.sampled)

--- a/basictracer/propagator.py
+++ b/basictracer/propagator.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from abc import ABCMeta, abstractmethod
+
+
+class Propagator(object):
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def inject(self, span_context, carrier):
+        pass
+
+    @abstractmethod
+    def extract(self, carrier):
+        pass

--- a/basictracer/tracer.py
+++ b/basictracer/tracer.py
@@ -20,7 +20,7 @@ class BasicTracer(Tracer):
         register_required_propagators().
 
         The required formats are opt-in because of protobuf version conflicts
-        with the binary carrior.
+        with the binary carrier.
         """
 
         super(BasicTracer, self).__init__()

--- a/basictracer/tracer.py
+++ b/basictracer/tracer.py
@@ -12,12 +12,29 @@ from .util import generate_id
 class BasicTracer(Tracer):
 
     def __init__(self, recorder=None, sampler=None):
+        """Initialize a BasicTracer instance.
+
+        Note that the returned BasicTracer has *no* propagators registered. The
+        user should either call register_propagator() for each needed
+        inject/extract format and/or the user can simply call
+        register_required_propagators().
+
+        The required formats are opt-in because of protobuf version conflicts
+        with the binary carrior.
+        """
+
         super(BasicTracer, self).__init__()
         self.recorder = NoopRecorder() if recorder is None else recorder
         self.sampler = DefaultSampler(1) if sampler is None else sampler
         self._propagators = {}
 
     def register_propagator(self, format, propagator):
+        """Register a propagator with this BasicTracer.
+
+        :param string format: a Format identifier like Format.TEXT_MAP
+        :param Propagator propagator: a Propagator instance to handle
+            inject/extract calls involving `format`
+        """
         self._propagators[format] = propagator
 
     def register_required_propagators(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,9 @@ from opentracing.harness.api_check import APICompatibilityCheckMixin
 
 class APICheckBasicTracer(unittest.TestCase, APICompatibilityCheckMixin):
     def tracer(self):
-        return BasicTracer()
+        t = BasicTracer()
+        t.register_required_propagators()
+        return t
 
     def check_baggage_values(self):
         return True

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -1,10 +1,11 @@
 import pytest
-from opentracing import child_of, Format, UnsupportedFormatException
+from opentracing import Format, UnsupportedFormatException
 from basictracer import BasicTracer
 
 
 def test_propagation():
     tracer = BasicTracer()
+    tracer.register_required_propagators()
     sp = tracer.start_span(operation_name='test')
     sp.context.sampled = False
     sp.context.set_baggage_item('foo', 'bar')
@@ -30,6 +31,7 @@ def test_propagation():
 def test_start_span():
     """ Test in process child span creation."""
     tracer = BasicTracer()
+    tracer.register_required_propagators()
     sp = tracer.start_span(operation_name='test')
     sp.context.set_baggage_item('foo', 'bar')
 


### PR DESCRIPTION
Make it possible for BasicTracer users to avoid even an *import* of the BinaryPropagator, as the latter can throw protobuf-related exceptions at initialization time.

cc: @bg451 