### PR TITLE
Make the tracer lib compatible with both Python 2 and 3.

### DIFF
--- a/basictracer/binary_propagator.py
+++ b/basictracer/binary_propagator.py
@@ -32,7 +32,7 @@ class BinaryPropagator(Propagator):
         if type(carrier) is not bytearray:
             raise InvalidCarrierException()
         state = TracerState()
-        state.ParseFromString(str(carrier[_proto_size_bytes:]))
+        state.ParseFromString(bytes(carrier[_proto_size_bytes:]))
         baggage = {}
         for k in state.baggage_items:
             baggage[k] = state.baggage_items[k]

--- a/basictracer/propagator.py
+++ b/basictracer/propagator.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod
+import six
 
 
-class Propagator(object):
-    __metaclass__ = ABCMeta
+class Propagator(six.with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def inject(self, span_context, carrier):

--- a/basictracer/recorder.py
+++ b/basictracer/recorder.py
@@ -1,13 +1,12 @@
 import threading
 
 from abc import ABCMeta, abstractmethod
+import six
 
 
-class SpanRecorder(object):
+class SpanRecorder(six.with_metaclass(ABCMeta, object)):
     """SpanRecorder is a simple abstract interface built around record_span.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def record_span(self, span):
@@ -37,13 +36,11 @@ class InMemoryRecorder(SpanRecorder):
             return self.spans[:]
 
 
-class Sampler(object):
+class Sampler(six.with_metaclass(ABCMeta, object)):
     """Sampler determines the sampling status of a span given its trace_id.
 
     Sampler.sampled() is expected to return a boolean.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def sampled(self, trace_id):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'futures',
         'protobuf>=3.0.0b2.post2',
         'opentracing>=1.2.1,<1.3',
-        'six<2.0',
+        'six>=1.10.0,<2.0',
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'futures',
         'protobuf>=3.0.0b2.post2',
         'opentracing>=1.2.1,<1.3',
-        'six>=1.10.0',
+        'six<2.0',
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     install_requires=[
         'futures',
         'protobuf>=3.0.0b2.post2',
-        'opentracing>=1.2.1,<1.3'
+        'opentracing>=1.2.1,<1.3',
+        'six>=1.10.0',
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
1. We add the six module as a requirement, as it
   provides a layer of compability between 2 and 3.
   Moreover, we use it for the metaclass declaration.
2. We use bytes() when extracting data from the binary
   propagator. For Python 2, this is simply an alias
   to 'str' (the use we used till now); and under 3,
   it keeps the same behaviour, as 'str' now converts
   to utf8, hence breaking the data/tests.