### PR TITLE
Add support for in-process context propagation

### DIFF
--- a/basictracer/active_span_source.py
+++ b/basictracer/active_span_source.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+import threading
+
+from opentracing.active_span_source import ActiveSpanSource
+
+
+class ThreadLocalActiveSpanSource(ActiveSpanSource):
+    """ActiveSpanSource implementation that stores the current active
+    `Span` in a thread-local storage.
+    """
+    def __init__(self):
+        self._tls_snapshot = threading.local()
+
+    def make_active(self, span):
+        self._tls_snapshot.active_span = span
+
+    def get_active(self):
+        return getattr(self._tls_snapshot, 'active_span', None)

--- a/basictracer/tracer.py
+++ b/basictracer/tracer.py
@@ -3,6 +3,7 @@ import time
 import opentracing
 from opentracing import Format, Tracer
 from opentracing import UnsupportedFormatException
+from .active_span_source import ThreadLocalActiveSpanSource
 from .context import SpanContext
 from .recorder import SpanRecorder, DefaultSampler
 from .span import BasicSpan
@@ -26,6 +27,7 @@ class BasicTracer(Tracer):
         super(BasicTracer, self).__init__()
         self.recorder = NoopRecorder() if recorder is None else recorder
         self.sampler = DefaultSampler(1) if sampler is None else sampler
+        self._active_span_source = ThreadLocalActiveSpanSource()
         self._propagators = {}
 
     def register_propagator(self, format, propagator):
@@ -44,13 +46,37 @@ class BasicTracer(Tracer):
         self.register_propagator(Format.HTTP_HEADERS, TextPropagator())
         self.register_propagator(Format.BINARY, BinaryPropagator())
 
-    def start_span(
+    def start_active_span(
             self,
             operation_name=None,
             child_of=None,
             references=None,
             tags=None,
-            start_time=None):
+            start_time=None,
+            ignore_active_span=False):
+
+        # create a new Span
+        span = self.start_manual_span(
+            operation_name=operation_name,
+            child_of=child_of,
+            references=references,
+            tags=tags,
+            start_time=start_time,
+            ignore_active_span=ignore_active_span,
+        )
+
+        # set the Span as active
+        self.active_span_source.make_active(span)
+        return span
+
+    def start_manual_span(
+            self,
+            operation_name=None,
+            child_of=None,
+            references=None,
+            tags=None,
+            start_time=None,
+            ignore_active_span=False):
 
         start_time = time.time() if start_time is None else start_time
 
@@ -63,6 +89,10 @@ class BasicTracer(Tracer):
         elif references is not None and len(references) > 0:
             # TODO only the first reference is currently used
             parent_ctx = references[0].referenced_context
+
+        # retrieve the active SpanContext
+        if not ignore_active_span and parent_ctx is None and self.active_span is not None:
+            parent_ctx = self.active_span.context
 
         # Assemble the child ctx
         ctx = SpanContext(span_id=generate_id())

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,7 @@
 -r requirements.txt
 
 -e .[tests]
+
+# TODO: using the latest proposal version; remove that after it has
+# been merged upstream
+-e git+https://github.com/palazzem/opentracing-python.git@palazzem/context-propagation-iter-2#egg=opentracing-1.2.3


### PR DESCRIPTION
### Overview

This PR adds in-process context propagation for the Tracer reference implementation. It pairs with https://github.com/opentracing/opentracing-python/pull/52 that is required to make it work. All implementation details should be discussed here, while API-related discussions should follow the other PR.

### Details
It implements the following API:
* `Span.capture()` and `Span.deactivate()`
* `Tracer.start_active_span()` and `Tracer.start_manual_span()`
* `Tracer.start_span()` is flagged as deprecated in the `opentracing` package
* the `Span` context manager doesn't finish a span if the `capture()` has been called
* add the `ThreadLocalActiveSpanSource` implementation that stores the current active span in a thread-local storage. It is intended to be used only in a subset of cases, since active span sources are pluggable and they can be developed in separated packages (contrib modules?)

What's missing and that will be completed after an initial review:
* [ ] tests for the new behaviors
* [ ] address the `deactivate()` issue
* [ ] use it in a real complex application before merging