### PR TITLE
Update our opentracing dependency to be >=1.21 and < 2.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     platforms='any',
     install_requires=[
         'protobuf>=3.0.0b2.post2',
-        'opentracing>=1.2.1,<1.3',
+        'opentracing>=1.2.1,<2.0',
         'six>=1.10.0,<2.0',
     ],
     extras_require={


### PR DESCRIPTION
This way we will get the latest version of the 1.x series,
which should be just fine, as no API breakage should happen.