### PR TITLE
Add support for Python 3.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
+dist: xenial
+
 language: python
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"
+
+matrix:
+  allow_failures:
+    - python: "3.8-dev"
 
 install:
   - make bootstrap

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ make bootstrap
 make test
 ```
 
+You can use [tox](https://tox.readthedocs.io) to run tests as well.
+```bash
+tox
+```
+
 ### Releases
 
 Before new release, add a summary of changes since last version to CHANGELOG.rst

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
@@ -28,10 +31,10 @@ setup(
     extras_require={
         'tests': [
             'doubles',
-            'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
+            'flake8',
             'flake8-quotes',
             'mock<1.1.0',
-            'pytest>=2.7,<3',
+            'pytest',
             'pytest-cov',
             'pytest-mock',
             'Sphinx',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py35,py36,py37
+
+[testenv]
+install_command = pip install {opts} {packages} {env:PWD}[tests]
+whitelist_externals = make
+commands =  make test lint


### PR DESCRIPTION
As a software engineer, I'd like to have support for modern versions of Python declared in `setup.py` and to have corresponding tests on CI.

Also, I'd like to be able to conveniently run tests in my local environment, so I want to add a `tox` config file.

These changes:
 - Add Python 3.5+ to `setup.py` and `.travis.yml`
 - Add `tox.ini`
 - Add a mention of `tox` into `Development` section of `README`
 - Simplify the tests requirements