### PR TITLE
provide meaningful error messages when failed to extract headers from carrier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ History
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- TextPropagator.extract raises SpanContextCorruptedException with
+  more meaningful error messages.
 
 
 3.1.0 (2019-05-12)
@@ -100,4 +101,3 @@ History
 ----------------
 
 - Initial public API
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ History
 - TextPropagator.extract raises SpanContextCorruptedException with
   more meaningful error messages.
 
+- Tracer.start_span validates type of ``references=`` preventing
+  problems for users migrating code from opentracing==1.3.0.
+
 
 3.1.0 (2019-05-12)
 ------------------

--- a/basictracer/text_propagator.py
+++ b/basictracer/text_propagator.py
@@ -16,7 +16,7 @@ def parse_hex_for_field(field_name, value):
     """parses the hexadecimal value of a field into an integer.
     Raises SpanContextCorruptedException in case of failure
     """
-    msg = "{field_name} got an invalid hexadecimal value {value!r}"
+    msg = '{field_name} got an invalid hexadecimal value {value!r}'
     msg = msg.format(field_name=field_name, value=value)
     try:
         return int(value, 16)
@@ -31,8 +31,8 @@ def parse_boolean_for_field(field_name, value):
         return False
 
     msg = (
-        "{field} got an invalid value {value!r}, "
-        "should be one of 'true', 'false', '0', '1'"
+        '{field} got an invalid value {value!r}, '
+        "should be one of \'true\', \'false\', \'0\', \'1\'"
     )
     raise SpanContextCorruptedException(msg.format(
         value=value,
@@ -72,8 +72,8 @@ class TextPropagator(Propagator):
 
         if count != field_count:
             msg = (
-                "expected to parse {field_count} fields"
-                ", but parsed {count} instead"
+                'expected to parse {field_count} fields'
+                ', but parsed {count} instead'
             )
             raise SpanContextCorruptedException(msg.format(
                 field_count=field_count,

--- a/basictracer/text_propagator.py
+++ b/basictracer/text_propagator.py
@@ -16,15 +16,18 @@ def parse_hex_for_field(field_name, value):
     """parses the hexadecimal value of a field into an integer.
     Raises SpanContextCorruptedException in case of failure
     """
-    msg = '{field_name} got an invalid hexadecimal value {value!r}'
-    msg = msg.format(field_name=field_name, value=value)
     try:
         return int(value, 16)
     except ValueError:
+        msg = '{field_name} got an invalid hexadecimal value {value!r}'
+        msg = msg.format(field_name=field_name, value=value)
         raise SpanContextCorruptedException(msg)
 
 
 def parse_boolean_for_field(field_name, value):
+    """parses the string value of a field into a boolean.
+    Raises SpanContextCorruptedException in case of failure
+    """
     if value in ('true', '1'):
         return True
     elif value in ('false', '0'):

--- a/basictracer/text_propagator.py
+++ b/basictracer/text_propagator.py
@@ -12,6 +12,34 @@ field_name_sampled = prefix_tracer_state + 'sampled'
 field_count = 3
 
 
+def parse_hex_for_field(field_name, value):
+    """parses the hexadecimal value of a field into an integer.
+    Raises SpanContextCorruptedException in case of failure
+    """
+    msg = "{field_name} got an invalid hexadecimal value {value!r}"
+    msg = msg.format(field_name=field_name, value=value)
+    try:
+        return int(value, 16)
+    except ValueError:
+        raise SpanContextCorruptedException(msg)
+
+
+def parse_boolean_for_field(field_name, value):
+    if value in ('true', '1'):
+        return True
+    elif value in ('false', '0'):
+        return False
+
+    msg = (
+        "{field} got an invalid value {value!r}, "
+        "should be one of 'true', 'false', '0', '1'"
+    )
+    raise SpanContextCorruptedException(msg.format(
+        value=value,
+        field=field_name_sampled
+    ))
+
+
 class TextPropagator(Propagator):
     """A BasicTracer Propagator for Format.TEXT_MAP."""
 
@@ -31,24 +59,26 @@ class TextPropagator(Propagator):
             v = carrier[k]
             k = k.lower()
             if k == field_name_span_id:
-                span_id = int(v, 16)
+                span_id = parse_hex_for_field(field_name_span_id, v)
                 count += 1
             elif k == field_name_trace_id:
-                trace_id = int(v, 16)
+                trace_id = parse_hex_for_field(field_name_trace_id, v)
                 count += 1
             elif k == field_name_sampled:
-                if v in ('true', '1'):
-                    sampled = True
-                elif v in ('false', '0'):
-                    sampled = False
-                else:
-                    raise SpanContextCorruptedException()
+                sampled = parse_boolean_for_field(field_name_sampled, v)
                 count += 1
             elif k.startswith(prefix_baggage):
                 baggage[k[len(prefix_baggage):]] = v
 
         if count != field_count:
-            raise SpanContextCorruptedException()
+            msg = (
+                "expected to parse {field_count} fields"
+                ", but parsed {count} instead"
+            )
+            raise SpanContextCorruptedException(msg.format(
+                field_count=field_count,
+                count=count,
+            ))
 
         return SpanContext(
             span_id=span_id,

--- a/basictracer/tracer.py
+++ b/basictracer/tracer.py
@@ -77,6 +77,9 @@ class BasicTracer(Tracer):
                    start_time=None,
                    ignore_active_span=False):
 
+        if isinstance(references, opentracing.Reference):
+            references = [references]
+
         start_time = time.time() if start_time is None else start_time
 
         # See if we have a parent_ctx in `references`
@@ -87,7 +90,14 @@ class BasicTracer(Tracer):
                 else child_of.context)
         elif references is not None and len(references) > 0:
             # TODO only the first reference is currently used
-            parent_ctx = references[0].referenced_context
+            first_ref = references[0]
+            if not isinstance(first_ref, opentracing.Reference):
+                msg = (
+                    'references[0] should be a opentracing.Reference '
+                    'objects, got %r instead'
+                )
+                raise TypeError(msg % first_ref)
+            parent_ctx = first_ref.referenced_context
 
         # retrieve the active SpanContext
         if not ignore_active_span and parent_ctx is None:

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -1,5 +1,9 @@
 import pytest
-from opentracing import Format, UnsupportedFormatException
+from opentracing import (
+    Format,
+    UnsupportedFormatException,
+    SpanContextCorruptedException,
+)
 from basictracer import BasicTracer
 
 
@@ -52,3 +56,75 @@ def test_start_span():
     assert child.context.sampled == sp.context.sampled
     assert child.context.baggage == sp.context.baggage
     assert child.parent_id == sp.context.span_id
+
+
+def test_span_corrupted_missing_fields():
+    tracer = BasicTracer()
+    tracer.register_required_propagators()
+
+    # Given an empty carrier
+    headers = {}
+
+    # When .extract is called
+    with pytest.raises(SpanContextCorruptedException) as exc:
+        tracer.extract(Format.TEXT_MAP, headers)
+
+    # Then it should raise SpanContextCorruptedException
+    assert str(exc.value) == 'expected to parse 3 fields, but parsed 0 instead'
+
+
+def test_span_corrupted_invalid_sampled_value():
+    tracer = BasicTracer()
+    tracer.register_required_propagators()
+
+    # Given a carrier with invalid "ot-tracer-sampled" value
+    headers = {
+        "ot-tracer-spanid": 'deadbeef',
+        "ot-tracer-sampled": 'notbool',
+        "ot-tracer-traceid": '1c3b00da',
+    }
+
+    # When .extract is called
+    with pytest.raises(SpanContextCorruptedException) as exc:
+        tracer.extract(Format.TEXT_MAP, headers)
+
+    # Then it should raise SpanContextCorruptedException
+    assert str(exc.value) == "ot-tracer-sampled got an invalid value 'notbool', should be one of 'true', 'false', '0', '1'"
+
+
+def test_span_corrupted_invalid_spanid_value():
+    tracer = BasicTracer()
+    tracer.register_required_propagators()
+
+    # Given a carrier with invalid "ot-tracer-spanid" value
+    headers = {
+        "ot-tracer-spanid": 'nothex',
+        "ot-tracer-sampled": 'false',
+        "ot-tracer-traceid": '1c3b00da',
+    }
+
+    # When .extract is called
+    with pytest.raises(SpanContextCorruptedException) as exc:
+        tracer.extract(Format.TEXT_MAP, headers)
+
+    # Then it should raise SpanContextCorruptedException
+    assert str(exc.value) == "ot-tracer-spanid got an invalid hexadecimal value 'nothex'"
+
+
+def test_span_corrupted_invalid_traceid_value():
+    tracer = BasicTracer()
+    tracer.register_required_propagators()
+
+    # Given a carrier with invalid "ot-tracer-traceid" value
+    headers = {
+        "ot-tracer-traceid": 'nothex',
+        "ot-tracer-sampled": 'false',
+        "ot-tracer-spanid": '1c3b00da',
+    }
+
+    # When .extract is called
+    with pytest.raises(SpanContextCorruptedException) as exc:
+        tracer.extract(Format.TEXT_MAP, headers)
+
+    # Then it should raise SpanContextCorruptedException
+    assert str(exc.value) == "ot-tracer-traceid got an invalid hexadecimal value 'nothex'"

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -79,9 +79,9 @@ def test_span_corrupted_invalid_sampled_value():
 
     # Given a carrier with invalid "ot-tracer-sampled" value
     headers = {
-        "ot-tracer-spanid": 'deadbeef',
-        "ot-tracer-sampled": 'notbool',
-        "ot-tracer-traceid": '1c3b00da',
+        'ot-tracer-spanid': 'deadbeef',
+        'ot-tracer-sampled': 'notbool',
+        'ot-tracer-traceid': '1c3b00da',
     }
 
     # When .extract is called
@@ -89,7 +89,10 @@ def test_span_corrupted_invalid_sampled_value():
         tracer.extract(Format.TEXT_MAP, headers)
 
     # Then it should raise SpanContextCorruptedException
-    assert str(exc.value) == "ot-tracer-sampled got an invalid value 'notbool', should be one of 'true', 'false', '0', '1'"
+    assert str(exc.value) == (
+        "ot-tracer-sampled got an invalid value 'notbool', "
+        "should be one of 'true', 'false', '0', '1'"
+    )
 
 
 def test_span_corrupted_invalid_spanid_value():
@@ -98,9 +101,9 @@ def test_span_corrupted_invalid_spanid_value():
 
     # Given a carrier with invalid "ot-tracer-spanid" value
     headers = {
-        "ot-tracer-spanid": 'nothex',
-        "ot-tracer-sampled": 'false',
-        "ot-tracer-traceid": '1c3b00da',
+        'ot-tracer-spanid': 'nothex',
+        'ot-tracer-sampled': 'false',
+        'ot-tracer-traceid': '1c3b00da',
     }
 
     # When .extract is called
@@ -108,18 +111,20 @@ def test_span_corrupted_invalid_spanid_value():
         tracer.extract(Format.TEXT_MAP, headers)
 
     # Then it should raise SpanContextCorruptedException
-    assert str(exc.value) == "ot-tracer-spanid got an invalid hexadecimal value 'nothex'"
+    assert str(exc.value) == (
+        "ot-tracer-spanid got an invalid hexadecimal value 'nothex'"
+    )
 
 
 def test_span_corrupted_invalid_traceid_value():
     tracer = BasicTracer()
     tracer.register_required_propagators()
 
-    # Given a carrier with invalid "ot-tracer-traceid" value
+    # Given a carrier with invalid 'ot-tracer-traceid' value
     headers = {
-        "ot-tracer-traceid": 'nothex',
-        "ot-tracer-sampled": 'false',
-        "ot-tracer-spanid": '1c3b00da',
+        'ot-tracer-traceid': 'nothex',
+        'ot-tracer-sampled': 'false',
+        'ot-tracer-spanid': '1c3b00da',
     }
 
     # When .extract is called
@@ -127,4 +132,6 @@ def test_span_corrupted_invalid_traceid_value():
         tracer.extract(Format.TEXT_MAP, headers)
 
     # Then it should raise SpanContextCorruptedException
-    assert str(exc.value) == "ot-tracer-traceid got an invalid hexadecimal value 'nothex'"
+    assert str(exc.value) == (
+        "ot-tracer-traceid got an invalid hexadecimal value 'nothex'"
+    )


### PR DESCRIPTION
This change can valuable time finding the root cause of Span Context corruption as well as a cryptic `AttributeError`