### PR TITLE
Having no tracing headers should not be an error.

### DIFF
--- a/basictracer/text_propagator.py
+++ b/basictracer/text_propagator.py
@@ -73,6 +73,13 @@ class TextPropagator(Propagator):
             elif k.startswith(prefix_baggage):
                 baggage[k[len(prefix_baggage):]] = v
 
+        if count == 0:
+            if len(baggage) > 0:
+                raise SpanContextCorruptedException(
+                                'found baggage without required fields')
+
+            return None
+
         if count != field_count:
             msg = (
                 'expected to parse {field_count} fields'


### PR DESCRIPTION
It is quite typical for services at the edge to receive requests with no
tracing headers. This case shouldn't throw an exception but rather return
None, as we are starting the root span. This is consistent with the
documented behavior of extract on Tracer:
https://github.com/opentracing/opentracing-python/blob/946f763510a8c26a66d5c53a9c4d0c6027cb9129/opentracing/tracer.py#L214